### PR TITLE
fix: Update alias versions handling

### DIFF
--- a/src/releez/cli.py
+++ b/src/releez/cli.py
@@ -14,7 +14,6 @@ from releez.artifact_version import (
 )
 from releez.cliff import GitCliff, GitCliffBump
 from releez.errors import (
-    AliasVersionsRequireFullReleaseError,
     ChangelogFormatCommandRequiredError,
     ReleezError,
 )
@@ -102,6 +101,12 @@ def _emit_artifact_version_output(
     alias_versions: AliasVersions,
 ) -> None:
     if scheme == ArtifactVersionScheme.pep440:
+        if alias_versions != AliasVersions.none:
+            typer.secho(
+                'Note: --alias-versions is ignored for --scheme pep440.',
+                err=True,
+                fg=typer.colors.YELLOW,
+            )
         typer.echo(artifact_version)
         return
 
@@ -110,7 +115,13 @@ def _emit_artifact_version_output(
         return
 
     if not is_full_release:
-        raise AliasVersionsRequireFullReleaseError
+        typer.secho(
+            'Note: --alias-versions is only applied for full releases; ignoring because --is-full-release is not set.',
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+        typer.echo(artifact_version)
+        return
 
     tags = compute_version_tags(version=artifact_version)
     for tag in select_tags(tags=tags, aliases=alias_versions):

--- a/src/releez/errors.py
+++ b/src/releez/errors.py
@@ -205,15 +205,6 @@ class InvalidReleaseVersionError(ReleezError):
         )
 
 
-class AliasVersionsRequireFullReleaseError(ReleezError):
-    """Raised when alias versions are requested for a non-full-release build."""
-
-    def __init__(self) -> None:
-        super().__init__(
-            'Alias versions are only supported for full releases (use --is-full-release).',
-        )
-
-
 class GitTagExistsError(ReleezError):
     """Raised when attempting to create a tag that already exists."""
 

--- a/tests/unit/cli/test_cli_version_artifact.py
+++ b/tests/unit/cli/test_cli_version_artifact.py
@@ -128,3 +128,38 @@ def test_cli_version_artifact_ignores_alias_versions_for_pep440(
     assert result.exit_code == 0
     assert result.stdout == '1.2.3\n'
     compute_tags.assert_not_called()
+
+
+def test_cli_version_artifact_ignores_alias_versions_for_prerelease(
+    mocker: MockerFixture,
+) -> None:
+    runner = CliRunner()
+    mocker.patch(
+        'releez.cli.compute_artifact_version',
+        return_value='1.2.3-alpha1-2',
+    )
+    compute_tags = mocker.patch('releez.cli.compute_version_tags')
+
+    result = runner.invoke(
+        cli.app,
+        [
+            'version',
+            'artifact',
+            '--scheme',
+            'docker',
+            '--version-override',
+            '1.2.3',
+            '--prerelease-type',
+            'alpha',
+            '--prerelease-number',
+            '1',
+            '--build-number',
+            '2',
+            '--alias-versions',
+            'major',
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert result.stdout == '1.2.3-alpha1-2\n'
+    compute_tags.assert_not_called()


### PR DESCRIPTION
- Ignore for pep440 instead of error
- Ignore for prerelease instead of error