### PR TITLE
chore(release): 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,31 @@
+## [0.3.0] - 2026-03-02
+
+### 🚀 Features
+
+- Post changelog hooks (#22) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#22](https://github.com/hotdog-werx/releez/pull/22)
+
+- Monorepo support with independent project versioning (#23) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#23](https://github.com/hotdog-werx/releez/pull/23)
+
+- Add documentation site (#24) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#24](https://github.com/hotdog-werx/releez/pull/24)
+
+### 🐛 Bug Fixes
+
+- Bump typer to 0.24.1 by [@jamestrousdale](https://github.com/jamestrousdale)
+
+- _(ci)_ Fix permissions on docs deploy job by
+  [@jamestrousdale](https://github.com/jamestrousdale)
+
+### ⚙️ Miscellaneous Tasks
+
+- _(docs)_ Link to GitHub pages docs by
+  [@jamestrousdale](https://github.com/jamestrousdale)
+
 ## [0.2.6] - 2026-02-18
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.0.0"
+version = "0.3.0"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "0.0.0"
+version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "git-cliff" },


### PR DESCRIPTION
## [0.3.0] - 2026-03-02


### 🚀 Features

- Post changelog hooks (#22) by [@jamestrousdale](https://github.com/jamestrousdale) in [#22](https://github.com/hotdog-werx/releez/pull/22)

- Monorepo support with independent project versioning (#23) by [@jamestrousdale](https://github.com/jamestrousdale) in [#23](https://github.com/hotdog-werx/releez/pull/23)

- Add documentation site (#24) by [@jamestrousdale](https://github.com/jamestrousdale) in [#24](https://github.com/hotdog-werx/releez/pull/24)


### 🐛 Bug Fixes

- Bump typer to 0.24.1 by [@jamestrousdale](https://github.com/jamestrousdale)

- *(ci)* Fix permissions on docs deploy job by [@jamestrousdale](https://github.com/jamestrousdale)


### ⚙️ Miscellaneous Tasks

- *(docs)* Link to GitHub pages docs by [@jamestrousdale](https://github.com/jamestrousdale)

