### PR TITLE
chore(release): 0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.3] - 2026-03-03
+
+### 🐛 Bug Fixes
+
+- _(action)_ Make sure action doesn't clobber alias-versions setting (#31) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#31](https://github.com/hotdog-werx/releez/pull/31)
+
 ## [0.3.2] - 2026-03-03
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.3.2"
+version = "0.3.3"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "0.3.2"
+version = "0.3.3"
 source = { editable = "." }
 dependencies = [
     { name = "git-cliff" },


### PR DESCRIPTION
## [0.3.3] - 2026-03-03


### 🐛 Bug Fixes

- *(action)* Make sure action doesn't clobber alias-versions setting (#31) by [@jamestrousdale](https://github.com/jamestrousdale) in [#31](https://github.com/hotdog-werx/releez/pull/31)

