### PR TITLE
chore(release): 0.3.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [0.3.4] - 2026-03-04
+
+### 🐛 Bug Fixes
+
+- Make releez.toml config paths the same as pyproject (#33) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#33](https://github.com/hotdog-werx/releez/pull/33)
+
 ## [0.3.3] - 2026-03-03
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "0.3.3"
+version = "0.3.4"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -709,7 +709,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "0.3.3"
+version = "0.3.4"
 source = { editable = "." }
 dependencies = [
     { name = "git-cliff" },


### PR DESCRIPTION
## [0.3.4] - 2026-03-04


### 🐛 Bug Fixes

- Make releez.toml config paths the same as pyproject (#33) by [@jamestrousdale](https://github.com/jamestrousdale) in [#33](https://github.com/hotdog-werx/releez/pull/33)

