### PR TITLE
feat: Validate commit message + validate-pr-title action mode

### DIFF
--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -19,5 +19,5 @@ jobs:
 
       - uses: ./
         with:
-          mode: validate-pr-title
-          pr-title: ${{ github.event.pull_request.title }}
+          mode: validate-commit
+          commit-message: ${{ github.event.pull_request.title }}

--- a/.github/workflows/lint-pr-title.yaml
+++ b/.github/workflows/lint-pr-title.yaml
@@ -13,8 +13,11 @@ jobs:
     name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: read
+      contents: read
     steps:
-      - uses: amannn/action-semantic-pull-request@v6
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v4
+
+      - uses: ./
+        with:
+          mode: validate-pr-title
+          pr-title: ${{ github.event.pull_request.title }}

--- a/action.yaml
+++ b/action.yaml
@@ -10,9 +10,10 @@ inputs:
   mode:
     description: |
       Action mode:
-        finalize        — Create tags and emit version outputs after a release PR is merged
-        validate        — Preview and validate a release PR before merge
+        finalize         — Create tags and emit version outputs after a release PR is merged
+        validate         — Preview and validate a release PR before merge
         version-artifact — Compute artifact versions for build pipelines
+        validate-pr-title — Check a PR title against cliff.toml commit parsers
     required: true
 
   # ── Common inputs ──────────────────────────────────────────────────────────
@@ -57,6 +58,13 @@ inputs:
     description: '[finalize] Skip tag creation and push (outputs are still computed)'
     required: false
     default: 'false'
+
+  # ── Validate-PR-title mode inputs ─────────────────────────────────────────
+
+  pr-title:
+    description: '[validate-pr-title] Commit message / PR title to validate against cliff.toml parsers.'
+    required: false
+    default: ''
 
   # ── Validate mode inputs ───────────────────────────────────────────────────
 
@@ -186,9 +194,9 @@ runs:
       shell: bash
       run: |
         case "${{ inputs.mode }}" in
-          finalize|validate|version-artifact) ;;
+          finalize|validate|version-artifact|validate-pr-title) ;;
           *)
-            echo "::error::Invalid mode '${{ inputs.mode }}'. Must be: finalize, validate, or version-artifact" >&2
+            echo "::error::Invalid mode '${{ inputs.mode }}'. Must be: finalize, validate, version-artifact, or validate-pr-title" >&2
             exit 1
             ;;
         esac
@@ -432,6 +440,13 @@ runs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
+    # ── VALIDATE-PR-TITLE MODE ───────────────────────────────────────────────
+
+    - name: '[validate-pr-title] Validate PR title against cliff.toml parsers'
+      if: inputs.mode == 'validate-pr-title'
+      shell: bash
+      run: releez validate commit-message "${{ inputs.pr-title }}"
+
     # ── AGGREGATE OUTPUTS ────────────────────────────────────────────────────
 
     - name: Set outputs
@@ -487,6 +502,13 @@ runs:
               [ -n "$JSON_RELEASE_VERSION" ] && VERSION="$JSON_RELEASE_VERSION"
               [ -n "$JSON_PROJECT" ] && PROJECT="$JSON_PROJECT"
             fi
+            ;;
+          validate-pr-title)
+            VERSION=""
+            PROJECT=""
+            VERSIONS_JSON=""
+            NOTES=""
+            PREVIEW=""
             ;;
         esac
 

--- a/action.yaml
+++ b/action.yaml
@@ -13,7 +13,7 @@ inputs:
         finalize         — Create tags and emit version outputs after a release PR is merged
         validate         — Preview and validate a release PR before merge
         version-artifact — Compute artifact versions for build pipelines
-        validate-pr-title — Check a PR title against cliff.toml commit parsers
+        validate-commit  — Check a commit message against cliff.toml commit parsers
     required: true
 
   # ── Common inputs ──────────────────────────────────────────────────────────
@@ -59,10 +59,10 @@ inputs:
     required: false
     default: 'false'
 
-  # ── Validate-PR-title mode inputs ─────────────────────────────────────────
+  # ── Validate-commit mode inputs ────────────────────────────────────────────
 
-  pr-title:
-    description: '[validate-pr-title] Commit message / PR title to validate against cliff.toml parsers.'
+  commit-message:
+    description: '[validate-commit] Commit message to validate against cliff.toml parsers.'
     required: false
     default: ''
 
@@ -194,9 +194,9 @@ runs:
       shell: bash
       run: |
         case "${{ inputs.mode }}" in
-          finalize|validate|version-artifact|validate-pr-title) ;;
+          finalize|validate|version-artifact|validate-commit) ;;
           *)
-            echo "::error::Invalid mode '${{ inputs.mode }}'. Must be: finalize, validate, version-artifact, or validate-pr-title" >&2
+            echo "::error::Invalid mode '${{ inputs.mode }}'. Must be: finalize, validate, version-artifact, or validate-commit" >&2
             exit 1
             ;;
         esac
@@ -440,12 +440,12 @@ runs:
           echo "EOF"
         } >> "$GITHUB_OUTPUT"
 
-    # ── VALIDATE-PR-TITLE MODE ───────────────────────────────────────────────
+    # ── VALIDATE-COMMIT MODE ─────────────────────────────────────────────────
 
-    - name: '[validate-pr-title] Validate PR title against cliff.toml parsers'
-      if: inputs.mode == 'validate-pr-title'
+    - name: '[validate-commit] Validate commit message against cliff.toml parsers'
+      if: inputs.mode == 'validate-commit'
       shell: bash
-      run: releez validate commit-message "${{ inputs.pr-title }}"
+      run: releez validate commit-message "${{ inputs.commit-message }}"
 
     # ── AGGREGATE OUTPUTS ────────────────────────────────────────────────────
 
@@ -503,7 +503,7 @@ runs:
               [ -n "$JSON_PROJECT" ] && PROJECT="$JSON_PROJECT"
             fi
             ;;
-          validate-pr-title)
+          validate-commit)
             VERSION=""
             PROJECT=""
             VERSIONS_JSON=""

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,7 +38,7 @@ postprocessors = [
 # See https://www.conventionalcommits.org
 conventional_commits = true
 # Exclude commits that do not match the conventional commits specification.
-filter_unconventional = false
+filter_unconventional = true
 # Require all commits to be conventional.
 # Takes precedence over filter_unconventional.
 require_conventional = false
@@ -77,7 +77,7 @@ commit_parsers = [
 # Exclude commits that are not matched by any commit parser.
 filter_commits = false
 # Fail on a commit that is not matched by any commit parser.
-fail_on_unmatched_commit = true
+fail_on_unmatched_commit = false
 # An array of link parsers for extracting external references, and turning them into URLs, using regex.
 link_parsers = []
 # Include only the tags that belong to the current branch.

--- a/cliff.toml
+++ b/cliff.toml
@@ -38,7 +38,7 @@ postprocessors = [
 # See https://www.conventionalcommits.org
 conventional_commits = true
 # Exclude commits that do not match the conventional commits specification.
-filter_unconventional = true
+filter_unconventional = false
 # Require all commits to be conventional.
 # Takes precedence over filter_unconventional.
 require_conventional = false
@@ -73,12 +73,11 @@ commit_parsers = [
   { message = "^chore|^ci", group = "<!-- 7 -->⚙️ Miscellaneous Tasks" },
   { body = ".*security", group = "<!-- 8 -->🛡️ Security" },
   { message = "^revert", group = "<!-- 9 -->◀️ Revert" },
-  { message = ".*", group = "<!-- 10 -->💼 Other" },
 ]
 # Exclude commits that are not matched by any commit parser.
 filter_commits = false
 # Fail on a commit that is not matched by any commit parser.
-fail_on_unmatched_commit = false
+fail_on_unmatched_commit = true
 # An array of link parsers for extracting external references, and turning them into URLs, using regex.
 link_parsers = []
 # Include only the tags that belong to the current branch.

--- a/docs/github-actions/action.md
+++ b/docs/github-actions/action.md
@@ -19,7 +19,7 @@ CLI version are always identical — version drift is impossible by construction
   - [finalize](#finalize)
   - [validate](#validate)
   - [version-artifact](#version-artifact)
-  - [validate-pr-title](#validate-pr-title)
+  - [validate-commit](#validate-commit)
 - [Monorepo support](#monorepo-support)
 - [Workflow recipes](#workflow-recipes)
 
@@ -27,12 +27,12 @@ CLI version are always identical — version drift is impossible by construction
 
 ## Modes
 
-| Mode                                      | Typical trigger                    | Purpose                                                       |
-| ----------------------------------------- | ---------------------------------- | ------------------------------------------------------------- |
-| [`finalize`](#finalize)                   | Release PR merged to main          | Create git tags, generate release notes, emit version outputs |
-| [`validate`](#validate)                   | PR opened / updated on `release/*` | Dry-run the release, post a preview comment on the PR         |
-| [`version-artifact`](#version-artifact)   | Any push or PR                     | Compute artifact version strings (semver / docker / pep440)   |
-| [`validate-pr-title`](#validate-pr-title) | PR opened / updated (any PR)       | Check that the PR title is a valid conventional commit type   |
+| Mode                                    | Typical trigger                    | Purpose                                                         |
+| --------------------------------------- | ---------------------------------- | --------------------------------------------------------------- |
+| [`finalize`](#finalize)                 | Release PR merged to main          | Create git tags, generate release notes, emit version outputs   |
+| [`validate`](#validate)                 | PR opened / updated on `release/*` | Dry-run the release, post a preview comment on the PR           |
+| [`version-artifact`](#version-artifact) | Any push or PR                     | Compute artifact version strings (semver / docker / pep440)     |
+| [`validate-commit`](#validate-commit)   | PR opened / updated (any PR)       | Check that a commit message is a valid conventional commit type |
 
 ---
 
@@ -42,7 +42,7 @@ CLI version are always identical — version drift is impossible by construction
 
 | Input              | Required | Default | Description                                                                                                                                                                                                                                                        |
 | ------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `mode`             | Yes      | —       | `finalize`, `validate`, `version-artifact`, or `validate-pr-title`                                                                                                                                                                                                 |
+| `mode`             | Yes      | —       | `finalize`, `validate`, `version-artifact`, or `validate-commit`                                                                                                                                                                                                   |
 | `releez-version`   | No       | `''`    | Override the releez CLI version to install. Bare version (`1.2.3`) installs from PyPI; full specifiers (`git+https://github.com/hotdog-werx/releez@branch`) are passed through to `uv tool install` unchanged. Defaults to the version co-located with the action. |
 | `is-full-release`  | No       | `true`  | `false` produces prerelease version strings                                                                                                                                                                                                                        |
 | `alias-versions`   | No       | `''`    | Optional override for alias tags on full releases: `none`, `major` (adds `v1`), or `minor` (adds `v1` and `v1.2`). When unset, releez config/defaults are used.                                                                                                    |
@@ -62,11 +62,11 @@ CLI version are always identical — version drift is impossible by construction
 | `post-comment` | `true`                    | Post / update a PR comment with the release preview and notes                                                  |
 | `comment-tag`  | `releez-validate-release` | Identifier for the PR comment — enables updating the same comment on every push instead of creating duplicates |
 
-### `validate-pr-title` inputs
+### `validate-commit` inputs
 
-| Input      | Required | Default | Description                                   |
-| ---------- | -------- | ------- | --------------------------------------------- |
-| `pr-title` | Yes      | `''`    | The PR title to validate against `cliff.toml` |
+| Input            | Required | Default | Description                                         |
+| ---------------- | -------- | ------- | --------------------------------------------------- |
+| `commit-message` | Yes      | `''`    | The commit message to validate against `cliff.toml` |
 
 ### `version-artifact` inputs
 
@@ -275,21 +275,21 @@ populated only when `detect-from-branch: 'true'` and the current branch is a
 
 ---
 
-### `validate-pr-title`
+### `validate-commit`
 
-Validates a PR title against the project's `cliff.toml` commit parsers — the
-same rules used at release time. This ensures that squash-and-merge commits
+Validates a commit message against the project's `cliff.toml` commit parsers —
+the same rules used at release time. This ensures that squash-and-merge commits
 produce a clean changelog without maintaining a separate validator config.
 
-A PR title is **valid** if it matches any named parser in `cliff.toml`,
-including `skip = true` parsers (e.g. `chore(release): 1.2.3`). Any unrecognised
-type or non-conventional format exits 1.
+A message is **valid** if it matches any named parser in `cliff.toml`, including
+`skip = true` parsers (e.g. `chore(release): 1.2.3`). Any unrecognised type or
+non-conventional format exits 1.
 
 ```yaml
 - uses: hotdog-werx/releez@v0
   with:
-    mode: validate-pr-title
-    pr-title: ${{ github.event.pull_request.title }}
+    mode: validate-commit
+    commit-message: ${{ github.event.pull_request.title }}
 ```
 
 **What this does**:
@@ -297,8 +297,8 @@ type or non-conventional format exits 1.
 - Derives a validation config from the project's `cliff.toml` with three
   overrides: `filter_unconventional = false`, `fail_on_unmatched_commit = true`,
   and catch-all parsers (`message = ".*"`) removed
-- Runs `releez validate commit-message "<title>"` and exits 0 or 1 accordingly
-- Fails the step (and the workflow job) if the title does not match any parser
+- Runs `releez validate commit-message "<message>"` and exits 0 or 1 accordingly
+- Fails the step (and the workflow job) if the message does not match any parser
 
 **Outputs populated**: none — this mode is purely a pass/fail check.
 
@@ -350,7 +350,7 @@ See [Monorepo Setup Guide](../monorepo/setup.md) for configuring projects,
 
 Complete copy-pasteable workflow examples:
 
-- [Validate PR titles](./workflow-recipes.md#recipe-0--validate-pr-titles-against-clifftomll)
+- [Validate commit messages / PR titles](./workflow-recipes.md#recipe-0--validate-commit-messages-against-clifftomll)
 - [Validate release PRs](./workflow-recipes.md#recipe-1--validate-a-release-pr)
 - [Finalize and create a GitHub Release](./workflow-recipes.md#recipe-2--finalize-a-release-and-publish-a-github-release)
 - [Publish to PyPI](./workflow-recipes.md#recipe-3--publish-a-python-package-to-pypi)

--- a/docs/github-actions/action.md
+++ b/docs/github-actions/action.md
@@ -19,6 +19,7 @@ CLI version are always identical — version drift is impossible by construction
   - [finalize](#finalize)
   - [validate](#validate)
   - [version-artifact](#version-artifact)
+  - [validate-pr-title](#validate-pr-title)
 - [Monorepo support](#monorepo-support)
 - [Workflow recipes](#workflow-recipes)
 
@@ -26,11 +27,12 @@ CLI version are always identical — version drift is impossible by construction
 
 ## Modes
 
-| Mode                                    | Typical trigger                    | Purpose                                                       |
-| --------------------------------------- | ---------------------------------- | ------------------------------------------------------------- |
-| [`finalize`](#finalize)                 | Release PR merged to main          | Create git tags, generate release notes, emit version outputs |
-| [`validate`](#validate)                 | PR opened / updated on `release/*` | Dry-run the release, post a preview comment on the PR         |
-| [`version-artifact`](#version-artifact) | Any push or PR                     | Compute artifact version strings (semver / docker / pep440)   |
+| Mode                                      | Typical trigger                    | Purpose                                                       |
+| ----------------------------------------- | ---------------------------------- | ------------------------------------------------------------- |
+| [`finalize`](#finalize)                   | Release PR merged to main          | Create git tags, generate release notes, emit version outputs |
+| [`validate`](#validate)                   | PR opened / updated on `release/*` | Dry-run the release, post a preview comment on the PR         |
+| [`version-artifact`](#version-artifact)   | Any push or PR                     | Compute artifact version strings (semver / docker / pep440)   |
+| [`validate-pr-title`](#validate-pr-title) | PR opened / updated (any PR)       | Check that the PR title is a valid conventional commit type   |
 
 ---
 
@@ -40,7 +42,7 @@ CLI version are always identical — version drift is impossible by construction
 
 | Input              | Required | Default | Description                                                                                                                                                                                                                                                        |
 | ------------------ | -------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `mode`             | Yes      | —       | `finalize`, `validate`, or `version-artifact`                                                                                                                                                                                                                      |
+| `mode`             | Yes      | —       | `finalize`, `validate`, `version-artifact`, or `validate-pr-title`                                                                                                                                                                                                 |
 | `releez-version`   | No       | `''`    | Override the releez CLI version to install. Bare version (`1.2.3`) installs from PyPI; full specifiers (`git+https://github.com/hotdog-werx/releez@branch`) are passed through to `uv tool install` unchanged. Defaults to the version co-located with the action. |
 | `is-full-release`  | No       | `true`  | `false` produces prerelease version strings                                                                                                                                                                                                                        |
 | `alias-versions`   | No       | `''`    | Optional override for alias tags on full releases: `none`, `major` (adds `v1`), or `minor` (adds `v1` and `v1.2`). When unset, releez config/defaults are used.                                                                                                    |
@@ -59,6 +61,12 @@ CLI version are always identical — version drift is impossible by construction
 | -------------- | ------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `post-comment` | `true`                    | Post / update a PR comment with the release preview and notes                                                  |
 | `comment-tag`  | `releez-validate-release` | Identifier for the PR comment — enables updating the same comment on every push instead of creating duplicates |
+
+### `validate-pr-title` inputs
+
+| Input      | Required | Default | Description                                   |
+| ---------- | -------- | ------- | --------------------------------------------- |
+| `pr-title` | Yes      | `''`    | The PR title to validate against `cliff.toml` |
 
 ### `version-artifact` inputs
 
@@ -267,6 +275,38 @@ populated only when `detect-from-branch: 'true'` and the current branch is a
 
 ---
 
+### `validate-pr-title`
+
+Validates a PR title against the project's `cliff.toml` commit parsers — the
+same rules used at release time. This ensures that squash-and-merge commits
+produce a clean changelog without maintaining a separate validator config.
+
+A PR title is **valid** if it matches any named parser in `cliff.toml`,
+including `skip = true` parsers (e.g. `chore(release): 1.2.3`). Any unrecognised
+type or non-conventional format exits 1.
+
+```yaml
+- uses: hotdog-werx/releez@v0
+  with:
+    mode: validate-pr-title
+    pr-title: ${{ github.event.pull_request.title }}
+```
+
+**What this does**:
+
+- Derives a validation config from the project's `cliff.toml` with three
+  overrides: `filter_unconventional = false`, `fail_on_unmatched_commit = true`,
+  and catch-all parsers (`message = ".*"`) removed
+- Runs `releez validate commit-message "<title>"` and exits 0 or 1 accordingly
+- Fails the step (and the workflow job) if the title does not match any parser
+
+**Outputs populated**: none — this mode is purely a pass/fail check.
+
+**Tip**: combine with `pull_request_target` if you need to validate PRs from
+forks (the workflow must have access to the repo's `cliff.toml`).
+
+---
+
 ## Monorepo support
 
 When the repo has `[[tool.releez.projects]]` configured, release branches use
@@ -310,6 +350,7 @@ See [Monorepo Setup Guide](../monorepo/setup.md) for configuring projects,
 
 Complete copy-pasteable workflow examples:
 
+- [Validate PR titles](./workflow-recipes.md#recipe-0--validate-pr-titles-against-clifftomll)
 - [Validate release PRs](./workflow-recipes.md#recipe-1--validate-a-release-pr)
 - [Finalize and create a GitHub Release](./workflow-recipes.md#recipe-2--finalize-a-release-and-publish-a-github-release)
 - [Publish to PyPI](./workflow-recipes.md#recipe-3--publish-a-python-package-to-pypi)

--- a/docs/github-actions/workflow-recipes.md
+++ b/docs/github-actions/workflow-recipes.md
@@ -5,12 +5,18 @@ the image name / registry / environment, and ship.
 
 ---
 
-## Recipe 0 — Validate PR titles against cliff.toml
+## Recipe 0 — Validate commit messages against cliff.toml
 
-Enforce that every PR title follows the project's `cliff.toml` commit parsers
-before it can be merged. Because `releez validate commit-message` reads the same
-config used at release time, adding a new type to `cliff.toml` immediately
-unblocks that type as a PR title — no separate validator list to maintain.
+Enforce that every PR title (and optionally every commit on a PR) follows the
+project's `cliff.toml` commit parsers before it can be merged. Because
+`releez validate commit-message` reads the same config used at release time,
+adding a new type to `cliff.toml` immediately unblocks that type — no separate
+validator list to maintain.
+
+### Validate the PR title (squash-and-merge workflow)
+
+In a squash-and-merge workflow the PR title becomes the commit message on
+`main`, so validating the title is sufficient for a clean changelog.
 
 ```yaml
 # .github/workflows/validate-pr-title.yaml
@@ -28,8 +34,8 @@ jobs:
 
       - uses: hotdog-werx/releez@v0
         with:
-          mode: validate-pr-title
-          pr-title: ${{ github.event.pull_request.title }}
+          mode: validate-commit
+          commit-message: ${{ github.event.pull_request.title }}
 ```
 
 **What counts as valid**:
@@ -47,12 +53,55 @@ jobs:
 - Non-conventional format: `WIP`, `half-done something`
 - Wrong case: `FEAT:`, `Fix:`
 
+### Validate every commit on a PR (rebase/merge-commit workflow)
+
+If your project uses rebase or merge-commit (not squash), every commit on the PR
+branch lands on `main` individually, so you may want to validate all of them.
+
+> **Note**: This is unnecessary in squash-and-merge workflows — validate the PR
+> title instead (see above). Running both is harmless but redundant.
+
+```yaml
+# .github/workflows/validate-commits.yaml
+name: Validate Commits
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  validate-commits:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate each commit message
+        env:
+          BASE: ${{ github.event.pull_request.base.sha }}
+          HEAD: ${{ github.event.pull_request.head.sha }}
+        run: |
+          fail=0
+          while IFS= read -r msg; do
+            if ! releez validate commit-message "$msg"; then
+              fail=1
+            fi
+          done < <(git log --format=%s "${BASE}..${HEAD}")
+          exit $fail
+        shell: bash
+```
+
+`git log --format=%s` prints the subject line (first line) of each commit.
+Adjust to `%B` if you want to validate the full commit body.
+
 ---
 
 ## Core concepts
 
 | Mode               | When to use                             | Key outputs                                                       |
 | ------------------ | --------------------------------------- | ----------------------------------------------------------------- |
+| `validate-commit`  | Any PR (validate title or commits)      | none — pass/fail only                                             |
 | `validate`         | PR opened / updated on a release branch | `release-preview`, `release-notes`, `validation-status`           |
 | `finalize`         | Release PR merged to main               | `release-version`, `release-notes`, semver/docker/pep440 versions |
 | `version-artifact` | Every build, on any branch              | semver/docker/pep440 version arrays                               |

--- a/docs/github-actions/workflow-recipes.md
+++ b/docs/github-actions/workflow-recipes.md
@@ -5,6 +5,50 @@ the image name / registry / environment, and ship.
 
 ---
 
+## Recipe 0 — Validate PR titles against cliff.toml
+
+Enforce that every PR title follows the project's `cliff.toml` commit parsers
+before it can be merged. Because `releez validate commit-message` reads the same
+config used at release time, adding a new type to `cliff.toml` immediately
+unblocks that type as a PR title — no separate validator list to maintain.
+
+```yaml
+# .github/workflows/validate-pr-title.yaml
+name: Validate PR Title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate-title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hotdog-werx/releez@v0
+        with:
+          mode: validate-pr-title
+          pr-title: ${{ github.event.pull_request.title }}
+```
+
+**What counts as valid**:
+
+- Any type configured as a named parser in `cliff.toml`: `feat`, `fix`, `chore`,
+  `ci`, etc.
+- `skip = true` parsers (e.g. `chore(release): 1.2.3`) are also valid
+- Breaking-change markers are accepted: `feat!:`, `fix(api)!:`
+- Scoped variants: `feat(scope):`, `fix(api):`
+
+**What is invalid**:
+
+- Any unrecognised type not present in `cliff.toml` (e.g. `wip:`, `docs:` if not
+  configured)
+- Non-conventional format: `WIP`, `half-done something`
+- Wrong case: `FEAT:`, `Fix:`
+
+---
+
 ## Core concepts
 
 | Mode               | When to use                             | Key outputs                                                       |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,10 +31,11 @@ dependencies = [
   "typer >=0.24.1,<0.25",
   "GitPython >= 3.1.45, <4",
   "PyGithub >= 2.8.1, <3",
-  "git-cliff >=2.11.0, <3",
+  "git-cliff >=2.12.0, <3",
   "semver >=3.0.1, <4",
   "pydantic >=2.7.0, <3",
   "pydantic-settings >=2.7.0, <3",
+  "tomli-w >=1.0.0, <2",
 ]
 
 [dependency-groups]

--- a/src/releez/cli.py
+++ b/src/releez/cli.py
@@ -1919,10 +1919,34 @@ def projects_info(
             typer.echo(f'    - {" ".join(hook)}')
 
 
+validate_app = typer.Typer(
+    help='Validate commit messages against cliff.toml rules.',
+)
+
+
+@validate_app.command('commit-message')
+def validate_commit_message(
+    message: Annotated[str, typer.Argument(help='Commit message to validate.')],
+) -> None:
+    """Check if a commit message matches a configured commit parser.
+
+    Exits 0 if valid, 1 if the message does not match any parser.
+    Useful for validating PR titles before merge.
+    """
+    _, repo_info = open_repo()
+    result = GitCliff(repo_root=repo_info.root).validate_commit_message(message)
+    if result.valid:
+        typer.secho(f'✓ {result.reason}', fg=typer.colors.GREEN)
+    else:
+        typer.secho(f'✗ {result.reason}', err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=1)
+
+
 app.add_typer(release_app, name='release')
 app.add_typer(version_app, name='version')
 app.add_typer(changelog_app, name='changelog')
 app.add_typer(projects_app, name='projects')
+app.add_typer(validate_app, name='validate')
 
 
 def main() -> None:

--- a/src/releez/cliff.py
+++ b/src/releez/cliff.py
@@ -5,9 +5,12 @@ import re
 import shutil
 import sysconfig
 import tempfile
+import tomllib
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
+
+import tomli_w
 
 from releez.errors import (
     ExternalCommandError,
@@ -28,6 +31,41 @@ class ReleaseNotes:
 
     version: str
     markdown: str
+
+
+@dataclass(frozen=True)
+class CommitValidationResult:
+    """Result of validating a commit message against the project's cliff.toml parsers."""
+
+    valid: bool
+    reason: str
+
+
+def _build_validation_config(cliff_toml_path: Path) -> dict[str, object]:
+    """Build a cliff.toml config dict suitable for commit message validation.
+
+    Reads the project's cliff.toml and applies three overrides to [git]:
+      - filter_unconventional = False  (non-conventional commits reach parsers)
+      - fail_on_unmatched_commit = True (unmatched commit → non-zero exit)
+      - removes catch-all parsers (message = ".*") so they don't swallow invalid msgs
+
+    Returns the modified config dict (ready for tomli_w.dumps()).
+    """
+    with cliff_toml_path.open('rb') as f:
+        config: dict[str, object] = tomllib.load(f)
+
+    git = config.setdefault('git', {})
+    if not isinstance(git, dict):
+        msg = f'Expected [git] to be a table, got {type(git).__name__}'
+        raise TypeError(msg)
+    git['filter_unconventional'] = False
+    git['fail_on_unmatched_commit'] = True
+    parsers = git.get('commit_parsers', [])
+    if not isinstance(parsers, list):
+        msg = f'Expected commit_parsers to be an array, got {type(parsers).__name__}'
+        raise TypeError(msg)
+    git['commit_parsers'] = [p for p in parsers if p.get('message') != '.*']
+    return config
 
 
 def _git_cliff_base_cmd() -> list[str]:
@@ -239,6 +277,44 @@ class GitCliff:
             cwd=self._repo_root,
             capture_stdout=False,
         )
+
+    def validate_commit_message(self, message: str) -> CommitValidationResult:
+        """Check if a commit message matches a parser in the project's cliff.toml.
+
+        Generates a temp cliff.toml from the real config with validation-safe overrides
+        (fail_on_unmatched_commit=True, filter_unconventional=False, no catch-all parsers)
+        and runs git-cliff --with-commit against it.
+
+        skip=true parsers still exit 0 — e.g. chore(release): 1.2.3 is a valid PR title.
+        Any non-zero exit (including git-cliff panics on unmatched commits) is invalid.
+        """
+        cliff_toml = self._repo_root / 'cliff.toml'
+        config = _build_validation_config(cliff_toml)
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            cfg = Path(tmp_dir) / 'cliff-validate.toml'
+            cfg.write_bytes(tomli_w.dumps(config).encode())
+            try:
+                run_checked(
+                    [
+                        *self._cmd,
+                        '--unreleased',
+                        '--with-commit',
+                        message,
+                        '--config',
+                        str(cfg),
+                    ],
+                    cwd=self._repo_root,
+                )
+                return CommitValidationResult(
+                    valid=True,
+                    reason='Valid: matches a commit parser',
+                )
+            except ExternalCommandError:
+                return CommitValidationResult(
+                    valid=False,
+                    reason='Invalid: does not match any commit parser (expected: type(scope?): subject)',
+                )
 
     def regenerate_changelog(
         self,

--- a/src/releez/cliff.py
+++ b/src/releez/cliff.py
@@ -292,8 +292,31 @@ class GitCliff:
         config = _build_validation_config(cliff_toml)
 
         with tempfile.TemporaryDirectory() as tmp_dir:
-            cfg = Path(tmp_dir) / 'cliff-validate.toml'
+            tmp = Path(tmp_dir)
+            cfg = tmp / 'cliff-validate.toml'
             cfg.write_bytes(tomli_w.dumps(config).encode())
+
+            # Run git-cliff in a fresh git repo so real history doesn't interfere.
+            # Without this, git-cliff processes all unreleased commits in the project
+            # repo and any non-conventional commit (e.g. a CI merge commit from a
+            # shallow checkout) causes a false failure via fail_on_unmatched_commit.
+            run_checked(['git', 'init', str(tmp)], cwd=tmp)
+            run_checked(
+                ['git', '-C', str(tmp), 'config', 'user.email', 'x@x.x'],
+            )
+            run_checked(['git', '-C', str(tmp), 'config', 'user.name', 'x'])
+            run_checked(
+                [
+                    'git',
+                    '-C',
+                    str(tmp),
+                    'commit',
+                    '--allow-empty',
+                    '-m',
+                    'chore: init',
+                ],
+            )
+
             try:
                 run_checked(
                     [
@@ -304,7 +327,7 @@ class GitCliff:
                         '--config',
                         str(cfg),
                     ],
-                    cwd=self._repo_root,
+                    cwd=tmp,
                 )
                 return CommitValidationResult(
                     valid=True,

--- a/src/releez/cliff.py
+++ b/src/releez/cliff.py
@@ -47,7 +47,13 @@ def _build_validation_config(cliff_toml_path: Path) -> dict[str, object]:
     Reads the project's cliff.toml and applies three overrides to [git]:
       - filter_unconventional = False  (non-conventional commits reach parsers)
       - fail_on_unmatched_commit = True (unmatched commit → non-zero exit)
-      - removes catch-all parsers (message = ".*") so they don't swallow invalid msgs
+      - removes catch-all parsers (message = ".*")
+
+    The catch-all removal is necessary because our filter_unconventional=False
+    override causes ".*" to match *any* raw commit message — including completely
+    non-conventional text like "half-done something".  Keeping ".*" would make
+    validation a no-op.  Stripping it preserves the intent of the project's
+    explicit parser list without silently bypassing the check.
 
     Returns the modified config dict (ready for tomli_w.dumps()).
     """

--- a/tests/action/test-action-validate-commit.yaml
+++ b/tests/action/test-action-validate-commit.yaml
@@ -1,25 +1,26 @@
-name: Test Action — validate-pr-title mode
+name: Test Action — validate-commit mode
 
-# Tests the validate-pr-title action mode, which runs
-# `releez validate commit-message "<pr-title>"` against the repo's cliff.toml.
+# Tests the validate-commit action mode, which runs
+# `releez validate commit-message "<message>"` against the repo's cliff.toml.
 #
-# Two jobs:
-#   1. valid title → action exits 0
-#   2. invalid title → action exits 1 (asserted via continue-on-error)
+# Three jobs:
+#   1. valid message → action exits 0
+#   2. invalid message → action exits 1 (asserted via continue-on-error)
+#   3. skip=true parser → action exits 0 (skip means omit, not reject)
 #
 # Run manually or via act:
-#   act workflow_dispatch -W tests/action/test-action-validate-pr-title.yaml
+#   act workflow_dispatch -W tests/action/test-action-validate-commit.yaml
 on:
   workflow_dispatch:
   workflow_call:
 
 jobs:
 
-  # ── Valid PR title ──────────────────────────────────────────────────────────
+  # ── Valid commit message ─────────────────────────────────────────────────────
   #
   # "feat: add new endpoint" matches the ^feat parser → action must exit 0.
-  test-valid-pr-title:
-    name: valid PR title exits 0
+  test-valid-commit:
+    name: valid commit message exits 0
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -46,30 +47,30 @@ jobs:
           TOML
         shell: bash
 
-      - name: Run action (valid title)
+      - name: Run action (valid commit message)
         id: releez
         uses: ./
         with:
-          mode: validate-pr-title
-          pr-title: 'feat: add new endpoint'
+          mode: validate-commit
+          commit-message: 'feat: add new endpoint'
 
       - name: Assert action succeeded
         run: |
           if [ "${{ steps.releez.outcome }}" = "success" ]; then
-            echo "OK [validate-pr-title]: valid title correctly accepted"
+            echo "OK [validate-commit]: valid message correctly accepted"
           else
-            echo "FAIL [validate-pr-title]: valid title was unexpectedly rejected"
+            echo "FAIL [validate-commit]: valid message was unexpectedly rejected"
             exit 1
           fi
         shell: bash
 
-  # ── Invalid PR title ────────────────────────────────────────────────────────
+  # ── Invalid commit message ───────────────────────────────────────────────────
   #
   # "half-done something" matches no parser → action must exit 1.
 
-  test-invalid-pr-title:
-    name: invalid PR title exits 1
-    needs: [test-valid-pr-title]
+  test-invalid-commit:
+    name: invalid commit message exits 1
+    needs: [test-valid-commit]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -97,32 +98,32 @@ jobs:
           TOML
         shell: bash
 
-      - name: Run action (invalid title — expect failure)
+      - name: Run action (invalid message — expect failure)
         id: bad
         continue-on-error: true
         uses: ./
         with:
-          mode: validate-pr-title
-          pr-title: 'half-done something'
+          mode: validate-commit
+          commit-message: 'half-done something'
 
       - name: Assert action failed
         run: |
           if [ "${{ steps.bad.outcome }}" = "failure" ]; then
-            echo "OK [validate-pr-title]: invalid title correctly rejected"
+            echo "OK [validate-commit]: invalid message correctly rejected"
           else
-            echo "FAIL [validate-pr-title]: invalid title should have been rejected but outcome was ${{ steps.bad.outcome }}"
+            echo "FAIL [validate-commit]: invalid message should have been rejected but outcome was ${{ steps.bad.outcome }}"
             exit 1
           fi
         shell: bash
 
-  # ── skip=true parser is valid ───────────────────────────────────────────────
+  # ── skip=true parser is valid ────────────────────────────────────────────────
   #
   # "chore(release): 1.2.3" matches a skip=true parser — it must still exit 0
   # (skip=true means "omit from changelog", not "reject").
 
   test-skip-parser-is-valid:
-    name: skip=true PR title exits 0
-    needs: [test-invalid-pr-title]
+    name: skip=true message exits 0
+    needs: [test-invalid-commit]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -150,19 +151,19 @@ jobs:
           TOML
         shell: bash
 
-      - name: Run action (skip=true title)
+      - name: Run action (skip=true message)
         id: releez
         uses: ./
         with:
-          mode: validate-pr-title
-          pr-title: 'chore(release): 1.2.3'
+          mode: validate-commit
+          commit-message: 'chore(release): 1.2.3'
 
       - name: Assert action succeeded
         run: |
           if [ "${{ steps.releez.outcome }}" = "success" ]; then
-            echo "OK [validate-pr-title]: skip=true title correctly accepted"
+            echo "OK [validate-commit]: skip=true message correctly accepted"
           else
-            echo "FAIL [validate-pr-title]: skip=true title was unexpectedly rejected"
+            echo "FAIL [validate-commit]: skip=true message was unexpectedly rejected"
             exit 1
           fi
         shell: bash

--- a/tests/action/test-action-validate-pr-title.yaml
+++ b/tests/action/test-action-validate-pr-title.yaml
@@ -1,0 +1,168 @@
+name: Test Action — validate-pr-title mode
+
+# Tests the validate-pr-title action mode, which runs
+# `releez validate commit-message "<pr-title>"` against the repo's cliff.toml.
+#
+# Two jobs:
+#   1. valid title → action exits 0
+#   2. invalid title → action exits 1 (asserted via continue-on-error)
+#
+# Run manually or via act:
+#   act workflow_dispatch -W tests/action/test-action-validate-pr-title.yaml
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+
+  # ── Valid PR title ──────────────────────────────────────────────────────────
+  #
+  # "feat: add new endpoint" matches the ^feat parser → action must exit 0.
+  test-valid-pr-title:
+    name: valid PR title exits 0
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Write test cliff.toml
+        run: |
+          cat > cliff.toml << 'TOML'
+          [changelog]
+          body = ""
+          render_always = false
+
+          [git]
+          conventional_commits = true
+          filter_unconventional = false
+          fail_on_unmatched_commit = true
+          commit_parsers = [
+            { message = "^feat", group = "Features" },
+            { message = "^fix", group = "Bug Fixes" },
+            { message = "^chore\\(release\\):", skip = true },
+            { message = "^chore\\(deps", skip = true },
+            { message = "^chore|^ci", group = "Misc" },
+          ]
+          TOML
+        shell: bash
+
+      - name: Run action (valid title)
+        id: releez
+        uses: ./
+        with:
+          mode: validate-pr-title
+          pr-title: 'feat: add new endpoint'
+
+      - name: Assert action succeeded
+        run: |
+          if [ "${{ steps.releez.outcome }}" = "success" ]; then
+            echo "OK [validate-pr-title]: valid title correctly accepted"
+          else
+            echo "FAIL [validate-pr-title]: valid title was unexpectedly rejected"
+            exit 1
+          fi
+        shell: bash
+
+  # ── Invalid PR title ────────────────────────────────────────────────────────
+  #
+  # "half-done something" matches no parser → action must exit 1.
+
+  test-invalid-pr-title:
+    name: invalid PR title exits 1
+    needs: [test-valid-pr-title]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Write test cliff.toml
+        run: |
+          cat > cliff.toml << 'TOML'
+          [changelog]
+          body = ""
+          render_always = false
+
+          [git]
+          conventional_commits = true
+          filter_unconventional = false
+          fail_on_unmatched_commit = true
+          commit_parsers = [
+            { message = "^feat", group = "Features" },
+            { message = "^fix", group = "Bug Fixes" },
+            { message = "^chore\\(release\\):", skip = true },
+            { message = "^chore\\(deps", skip = true },
+            { message = "^chore|^ci", group = "Misc" },
+          ]
+          TOML
+        shell: bash
+
+      - name: Run action (invalid title — expect failure)
+        id: bad
+        continue-on-error: true
+        uses: ./
+        with:
+          mode: validate-pr-title
+          pr-title: 'half-done something'
+
+      - name: Assert action failed
+        run: |
+          if [ "${{ steps.bad.outcome }}" = "failure" ]; then
+            echo "OK [validate-pr-title]: invalid title correctly rejected"
+          else
+            echo "FAIL [validate-pr-title]: invalid title should have been rejected but outcome was ${{ steps.bad.outcome }}"
+            exit 1
+          fi
+        shell: bash
+
+  # ── skip=true parser is valid ───────────────────────────────────────────────
+  #
+  # "chore(release): 1.2.3" matches a skip=true parser — it must still exit 0
+  # (skip=true means "omit from changelog", not "reject").
+
+  test-skip-parser-is-valid:
+    name: skip=true PR title exits 0
+    needs: [test-invalid-pr-title]
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Write test cliff.toml
+        run: |
+          cat > cliff.toml << 'TOML'
+          [changelog]
+          body = ""
+          render_always = false
+
+          [git]
+          conventional_commits = true
+          filter_unconventional = false
+          fail_on_unmatched_commit = true
+          commit_parsers = [
+            { message = "^feat", group = "Features" },
+            { message = "^fix", group = "Bug Fixes" },
+            { message = "^chore\\(release\\):", skip = true },
+            { message = "^chore\\(deps", skip = true },
+            { message = "^chore|^ci", group = "Misc" },
+          ]
+          TOML
+        shell: bash
+
+      - name: Run action (skip=true title)
+        id: releez
+        uses: ./
+        with:
+          mode: validate-pr-title
+          pr-title: 'chore(release): 1.2.3'
+
+      - name: Assert action succeeded
+        run: |
+          if [ "${{ steps.releez.outcome }}" = "success" ]; then
+            echo "OK [validate-pr-title]: skip=true title correctly accepted"
+          else
+            echo "FAIL [validate-pr-title]: skip=true title was unexpectedly rejected"
+            exit 1
+          fi
+        shell: bash

--- a/tests/integration/test_validate_workflow.py
+++ b/tests/integration/test_validate_workflow.py
@@ -1,0 +1,102 @@
+"""Integration tests for commit message validation against real git-cliff.
+
+Each test creates a self-contained git repository in tmp_path with a
+standalone cliff.toml — no dependency on the releez project's own cliff.toml.
+
+The fixture cliff.toml is deliberately written with the "wrong" settings
+(filter_unconventional=true, fail_on_unmatched=false, catch-all present) so
+that the tests also exercise _build_validation_config() applying the overrides.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from git import Repo
+
+from releez.cliff import GitCliff
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# Fixture cliff.toml intentionally has settings that would NOT trigger
+# fail_on_unmatched_commit on their own (filter_unconventional=true silently
+# drops non-conventional commits, catch-all swallows everything else).
+# _build_validation_config() must override all three to make validation work.
+_FIXTURE_CLIFF_TOML = """\
+[changelog]
+body = ""
+render_always = false
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+fail_on_unmatched_commit = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Fixes" },
+  { message = "^chore\\\\(release\\\\):", skip = true },
+  { message = "^chore\\\\(deps", skip = true },
+  { message = "^chore|^ci", group = "Misc" },
+  { message = ".*", group = "Other" },
+]
+"""
+
+
+def _setup_repo(tmp_path: Path) -> None:
+    """Initialise a git repo with an initial commit and the fixture cliff.toml."""
+    (tmp_path / 'cliff.toml').write_text(_FIXTURE_CLIFF_TOML, encoding='utf-8')
+    repo = Repo.init(tmp_path)
+    repo.config_writer().set_value('user', 'name', 'Test').release()
+    repo.config_writer().set_value(
+        'user',
+        'email',
+        'test@example.com',
+    ).release()
+    (tmp_path / 'README.md').write_text('# test\n', encoding='utf-8')
+    repo.index.add(['cliff.toml', 'README.md'])
+    repo.index.commit('feat: initial commit')
+
+
+@pytest.mark.parametrize(
+    ('message', 'expected_valid'),
+    [
+        # ── Valid: matches a named parser ──────────────────────────────────
+        ('feat: add new feature', True),
+        ('fix: correct a bug', True),
+        ('feat(scope): scoped feature', True),
+        ('fix(api): scoped fix', True),
+        ('feat!: breaking change', True),
+        ('fix(api)!: breaking scoped fix', True),
+        ('chore: miscellaneous task', True),
+        ('ci: update workflow', True),
+        # ── Valid: skip=true parser matched — still a valid PR title ───────
+        ('chore(release): 1.2.3', True),
+        ('chore(deps): bump something', True),
+        # ── Invalid: non-conventional format ──────────────────────────────
+        ('half-done something', False),
+        ('just a sentence without type', False),
+        ('WIP', False),
+        # ── Invalid: conventional format but type not in fixture parsers ───
+        ('wip: something', False),
+        ('docs: update readme', False),
+        ('perf: speed improvement', False),
+        ('refactor: clean up', False),
+        ('test: add tests', False),
+        # ── Invalid: wrong case (conventional commits are lowercase type) ──
+        ('FEAT: something', False),
+        ('Fix: something', False),
+    ],
+)
+def test_validate_commit_message(
+    message: str,
+    expected_valid: bool,  # noqa: FBT001
+    tmp_path: Path,
+) -> None:
+    _setup_repo(tmp_path)
+    cliff = GitCliff(repo_root=tmp_path)
+    result = cliff.validate_commit_message(message)
+    assert result.valid is expected_valid, (
+        f'Message {message!r}: expected valid={expected_valid}, got valid={result.valid} (reason: {result.reason})'
+    )

--- a/tests/integration/test_validate_workflow.py
+++ b/tests/integration/test_validate_workflow.py
@@ -4,8 +4,9 @@ Each test creates a self-contained git repository in tmp_path with a
 standalone cliff.toml — no dependency on the releez project's own cliff.toml.
 
 The fixture cliff.toml is deliberately written with the "wrong" settings
-(filter_unconventional=true, fail_on_unmatched=false, catch-all present) so
-that the tests also exercise _build_validation_config() applying the overrides.
+(filter_unconventional=true, fail_on_unmatched=false) so that the tests also
+exercise _build_validation_config() applying the two overrides. No catch-all
+parser is present so that unknown types are correctly rejected.
 """
 
 from __future__ import annotations
@@ -20,10 +21,10 @@ from releez.cliff import GitCliff
 if TYPE_CHECKING:
     from pathlib import Path
 
-# Fixture cliff.toml intentionally has settings that would NOT trigger
-# fail_on_unmatched_commit on their own (filter_unconventional=true silently
-# drops non-conventional commits, catch-all swallows everything else).
-# _build_validation_config() must override all three to make validation work.
+# Fixture cliff.toml intentionally has filter_unconventional=true and
+# fail_on_unmatched=false so that the tests also exercise
+# _build_validation_config() applying the two overrides.
+# No catch-all parser (".*") is present — unknown types should be rejected.
 _FIXTURE_CLIFF_TOML = """\
 [changelog]
 body = ""
@@ -39,7 +40,6 @@ commit_parsers = [
   { message = "^chore\\\\(release\\\\):", skip = true },
   { message = "^chore\\\\(deps", skip = true },
   { message = "^chore|^ci", group = "Misc" },
-  { message = ".*", group = "Other" },
 ]
 """
 
@@ -95,6 +95,76 @@ def test_validate_commit_message(
     tmp_path: Path,
 ) -> None:
     _setup_repo(tmp_path)
+    cliff = GitCliff(repo_root=tmp_path)
+    result = cliff.validate_commit_message(message)
+    assert result.valid is expected_valid, (
+        f'Message {message!r}: expected valid={expected_valid}, got valid={result.valid} (reason: {result.reason})'
+    )
+
+
+# ---------------------------------------------------------------------------
+# Regression: ".*" catch-all still requires conventional commit format
+# ---------------------------------------------------------------------------
+
+_CATCHALL_CLIFF_TOML = """\
+[changelog]
+body = ""
+render_always = false
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+fail_on_unmatched_commit = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^chore", group = "Misc" },
+  { message = ".*", group = "Other" },
+]
+"""
+
+
+@pytest.mark.parametrize(
+    ('message', 'expected_valid'),
+    [
+        # "^feat" parser survives stripping — feat: is valid
+        ('feat: known type', True),
+        ('feat(scope): scoped', True),
+        # ".*" is stripped by _build_validation_config, so unknown types are
+        # rejected even though they were "caught" by ".*" in the source config.
+        ('wip: unknown type', False),
+        ('docs: not in explicit parsers', False),
+        # Non-conventional format was matched by ".*" in the source config, but
+        # ".*" is stripped so these are now correctly rejected.
+        ('half-done something', False),
+        ('just a sentence', False),
+        ('WIP', False),
+        ('FEAT: wrong case', False),
+    ],
+)
+def test_catchall_parser_is_stripped_for_validation(
+    message: str,
+    expected_valid: bool,  # noqa: FBT001
+    tmp_path: Path,
+) -> None:
+    """Regression: a ".*" catch-all in cliff.toml is stripped by build_validation_config before running git-cliff.
+
+    Without stripping, our filter_unconventional=False override causes ".*" to
+    match *any* raw commit message — including completely non-conventional text
+    like "half-done something" — making validation a no-op.  Stripping ".*"
+    preserves the intent of the project's explicit parser list.
+    """
+    (tmp_path / 'cliff.toml').write_text(_CATCHALL_CLIFF_TOML, encoding='utf-8')
+    repo = Repo.init(tmp_path)
+    repo.config_writer().set_value('user', 'name', 'Test').release()
+    repo.config_writer().set_value(
+        'user',
+        'email',
+        'test@example.com',
+    ).release()
+    (tmp_path / 'README.md').write_text('# test\n', encoding='utf-8')
+    repo.index.add(['cliff.toml', 'README.md'])
+    repo.index.commit('chore: initial commit')
+
     cliff = GitCliff(repo_root=tmp_path)
     result = cliff.validate_commit_message(message)
     assert result.valid is expected_valid, (

--- a/tests/unit/cli/test_cli_validate.py
+++ b/tests/unit/cli/test_cli_validate.py
@@ -1,0 +1,92 @@
+"""Tests for the `validate commit-message` CLI subcommand."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from typer.testing import CliRunner
+
+from releez import cli
+from releez.cliff import CommitValidationResult
+
+if TYPE_CHECKING:
+    from pytest_mock import MockerFixture
+
+
+runner = CliRunner()
+
+
+def _mock_validate(mocker: MockerFixture, *, valid: bool) -> None:
+    reason = (
+        'Valid: matches a commit parser'
+        if valid
+        else ('Invalid: does not match any commit parser (expected: type(scope?): subject)')
+    )
+    mocker.patch(
+        'releez.cli.GitCliff.validate_commit_message',
+        return_value=CommitValidationResult(valid=valid, reason=reason),
+    )
+    mocker.patch(
+        'releez.cli.open_repo',
+        return_value=(mocker.MagicMock(), mocker.MagicMock(root='/fake/repo')),
+    )
+
+
+def test_valid_message_exits_0(mocker: MockerFixture) -> None:
+    _mock_validate(mocker, valid=True)
+    result = runner.invoke(
+        cli.app,
+        ['validate', 'commit-message', 'feat: add feature'],
+    )
+    assert result.exit_code == 0
+    assert '✓' in result.output
+
+
+def test_valid_message_prints_reason(mocker: MockerFixture) -> None:
+    _mock_validate(mocker, valid=True)
+    result = runner.invoke(
+        cli.app,
+        ['validate', 'commit-message', 'feat: add feature'],
+    )
+    assert 'Valid: matches a commit parser' in result.output
+
+
+def test_invalid_message_exits_1(mocker: MockerFixture) -> None:
+    _mock_validate(mocker, valid=False)
+    result = runner.invoke(
+        cli.app,
+        ['validate', 'commit-message', 'bad message'],
+    )
+    assert result.exit_code == 1
+
+
+def test_invalid_message_prints_reason_to_stderr(mocker: MockerFixture) -> None:
+    _mock_validate(mocker, valid=False)
+    result = runner.invoke(
+        cli.app,
+        ['validate', 'commit-message', 'bad message'],
+        catch_exceptions=False,
+    )
+    assert '✗' in result.output
+    assert 'Invalid' in result.output
+
+
+def test_message_is_passed_to_validate(mocker: MockerFixture) -> None:
+    captured: list[str] = []
+    reason = 'Valid: matches a commit parser'
+
+    def _capture(self: object, message: str) -> CommitValidationResult:
+        captured.append(message)
+        return CommitValidationResult(valid=True, reason=reason)
+
+    mocker.patch('releez.cli.GitCliff.validate_commit_message', _capture)
+    mocker.patch(
+        'releez.cli.open_repo',
+        return_value=(mocker.MagicMock(), mocker.MagicMock(root='/fake/repo')),
+    )
+
+    runner.invoke(
+        cli.app,
+        ['validate', 'commit-message', 'feat(api): my message'],
+    )
+    assert captured == ['feat(api): my message']

--- a/tests/unit/core/test_cliff_validate.py
+++ b/tests/unit/core/test_cliff_validate.py
@@ -188,12 +188,10 @@ def test_validate_returns_invalid_on_nonzero_exit(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    def _fail(*_a: object, **_kw: object) -> str:
-        raise ExternalCommandError(
-            cmd_args=['git-cliff'],
-            returncode=101,
-            stderr='',
-        )
+    def _fail(cmd: list[str], **_kw: object) -> str:
+        if 'git-cliff' in cmd[0]:
+            raise ExternalCommandError(cmd_args=cmd, returncode=101, stderr='')
+        return ''
 
     monkeypatch.setattr(releez.cliff, 'run_checked', _fail)
     cliff = _make_cliff(tmp_path, monkeypatch)
@@ -217,8 +215,10 @@ def test_validate_passes_with_commit_and_config_flags(
     cliff = _make_cliff(tmp_path, monkeypatch)
     cliff.validate_commit_message('feat: test')
 
-    assert len(captured) == 1
-    cmd = captured[0]
+    # Find the git-cliff call (others are git setup commands for the temp repo)
+    cliff_calls = [cmd for cmd in captured if 'git-cliff' in cmd[0]]
+    assert len(cliff_calls) == 1
+    cmd = cliff_calls[0]
     assert '--with-commit' in cmd
     assert 'feat: test' in cmd
     assert '--config' in cmd

--- a/tests/unit/core/test_cliff_validate.py
+++ b/tests/unit/core/test_cliff_validate.py
@@ -1,0 +1,225 @@
+"""Unit tests for commit message validation in cliff.py.
+
+Tests are split into two groups:
+  1. _build_validation_config() — pure config transformation, no subprocess.
+  2. GitCliff.validate_commit_message() — subprocess mocked via monkeypatch.
+
+All tests use standalone cliff.toml fixtures written to tmp_path; they never
+read the project's own cliff.toml.
+"""
+
+from __future__ import annotations
+
+import tomllib
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from pathlib import Path
+import tomli_w
+
+import releez.cliff
+from releez.cliff import (
+    CommitValidationResult,
+    GitCliff,
+    _build_validation_config,
+)
+from releez.errors import ExternalCommandError
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+_FIXTURE_TOML = """\
+[git]
+conventional_commits = true
+filter_unconventional = true
+fail_on_unmatched_commit = false
+commit_parsers = [
+  { message = "^feat", group = "Features" },
+  { message = "^fix", group = "Fixes" },
+  { message = "^chore\\\\(release\\\\):", skip = true },
+  { message = ".*", group = "Other" },
+]
+"""
+
+_NO_GIT_SECTION_TOML = """\
+[changelog]
+body = ""
+render_always = false
+"""
+
+
+def _write_cliff_toml(tmp_path: Path, content: str = _FIXTURE_TOML) -> Path:
+    p = tmp_path / 'cliff.toml'
+    p.write_text(content, encoding='utf-8')
+    return p
+
+
+# ---------------------------------------------------------------------------
+# _build_validation_config — config transformation tests
+# ---------------------------------------------------------------------------
+
+
+def test_forces_filter_unconventional_false(tmp_path: Path) -> None:
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path))
+    assert cfg['git']['filter_unconventional'] is False  # type: ignore[index]
+
+
+def test_forces_fail_on_unmatched_commit_true(tmp_path: Path) -> None:
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path))
+    assert cfg['git']['fail_on_unmatched_commit'] is True  # type: ignore[index]
+
+
+def test_removes_catchall_parser(tmp_path: Path) -> None:
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path))
+    parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
+    assert not any(p.get('message') == '.*' for p in parsers)
+
+
+def test_preserves_named_parsers(tmp_path: Path) -> None:
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path))
+    parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
+    messages = [p['message'] for p in parsers]
+    assert '^feat' in messages
+    assert '^fix' in messages
+
+
+def test_preserves_skip_true_parsers(tmp_path: Path) -> None:
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path))
+    parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
+    assert any(p.get('skip') is True for p in parsers)
+
+
+def test_no_git_section_creates_git_section(tmp_path: Path) -> None:
+    cfg = _build_validation_config(
+        _write_cliff_toml(tmp_path, _NO_GIT_SECTION_TOML),
+    )
+    assert cfg['git']['filter_unconventional'] is False  # type: ignore[index]
+    assert cfg['git']['fail_on_unmatched_commit'] is True  # type: ignore[index]
+    assert cfg['git']['commit_parsers'] == []  # type: ignore[index]
+
+
+def test_output_round_trips_as_valid_toml(tmp_path: Path) -> None:
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path))
+    rendered = tomli_w.dumps(cfg)
+    parsed = tomllib.loads(rendered)
+    assert parsed['git']['fail_on_unmatched_commit'] is True
+    assert parsed['git']['filter_unconventional'] is False
+    assert not any(p.get('message') == '.*' for p in parsed['git']['commit_parsers'])
+
+
+def test_no_parsers_in_source_stays_empty(tmp_path: Path) -> None:
+    toml = '[git]\nconventional_commits = true\n'
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path, toml))
+    assert cfg['git']['commit_parsers'] == []  # type: ignore[index]
+
+
+def test_raises_type_error_if_git_is_not_a_dict(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(tomllib, 'load', lambda _f: {'git': 'not-a-dict'})
+    with pytest.raises(TypeError, match='Expected \\[git\\] to be a table'):
+        _build_validation_config(_write_cliff_toml(tmp_path))
+
+
+def test_raises_type_error_if_commit_parsers_is_not_a_list(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        tomllib,
+        'load',
+        lambda _f: {'git': {'commit_parsers': 'not-a-list'}},
+    )
+    with pytest.raises(
+        TypeError,
+        match='Expected commit_parsers to be an array',
+    ):
+        _build_validation_config(_write_cliff_toml(tmp_path))
+
+
+def test_multiple_catchalls_all_removed(tmp_path: Path) -> None:
+    toml = (
+        '[git]\n'
+        'commit_parsers = [\n'
+        '  { message = "^feat", group = "Features" },\n'
+        '  { message = ".*", group = "Other1" },\n'
+        '  { message = ".*", group = "Other2" },\n'
+        ']\n'
+    )
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path, toml))
+    parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
+    assert len(parsers) == 1
+    assert parsers[0]['message'] == '^feat'
+
+
+# ---------------------------------------------------------------------------
+# GitCliff.validate_commit_message — subprocess mocked
+# ---------------------------------------------------------------------------
+
+
+def _make_cliff(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> GitCliff:
+    """Return a GitCliff instance with _git_cliff_base_cmd patched."""
+    monkeypatch.setattr(
+        releez.cliff,
+        '_git_cliff_base_cmd',
+        lambda: ['git-cliff'],
+    )
+    _write_cliff_toml(tmp_path)
+    return GitCliff(repo_root=tmp_path)
+
+
+def test_validate_returns_valid_on_exit_0(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(releez.cliff, 'run_checked', lambda *_a, **_kw: '')
+    cliff = _make_cliff(tmp_path, monkeypatch)
+    result = cliff.validate_commit_message('feat: something')
+    assert isinstance(result, CommitValidationResult)
+    assert result.valid is True
+    assert result.reason
+
+
+def test_validate_returns_invalid_on_nonzero_exit(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _fail(*_a: object, **_kw: object) -> str:
+        raise ExternalCommandError(
+            cmd_args=['git-cliff'],
+            returncode=101,
+            stderr='',
+        )
+
+    monkeypatch.setattr(releez.cliff, 'run_checked', _fail)
+    cliff = _make_cliff(tmp_path, monkeypatch)
+    result = cliff.validate_commit_message('bad message')
+    assert isinstance(result, CommitValidationResult)
+    assert result.valid is False
+    assert result.reason
+
+
+def test_validate_passes_with_commit_and_config_flags(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[list[str]] = []
+
+    def _capture(cmd: list[str], **_kw: object) -> str:
+        captured.append(cmd)
+        return ''
+
+    monkeypatch.setattr(releez.cliff, 'run_checked', _capture)
+    cliff = _make_cliff(tmp_path, monkeypatch)
+    cliff.validate_commit_message('feat: test')
+
+    assert len(captured) == 1
+    cmd = captured[0]
+    assert '--with-commit' in cmd
+    assert 'feat: test' in cmd
+    assert '--config' in cmd
+    assert '--unreleased' in cmd

--- a/tests/unit/core/test_cliff_validate.py
+++ b/tests/unit/core/test_cliff_validate.py
@@ -73,6 +73,9 @@ def test_forces_fail_on_unmatched_commit_true(tmp_path: Path) -> None:
 
 
 def test_removes_catchall_parser(tmp_path: Path) -> None:
+    # ".*" must be stripped: our filter_unconventional=False override causes it
+    # to match *any* raw text (including "half-done something"), making
+    # validation a no-op if kept.
     cfg = _build_validation_config(_write_cliff_toml(tmp_path))
     parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
     assert not any(p.get('message') == '.*' for p in parsers)
@@ -116,6 +119,21 @@ def test_no_parsers_in_source_stays_empty(tmp_path: Path) -> None:
     assert cfg['git']['commit_parsers'] == []  # type: ignore[index]
 
 
+def test_multiple_catchalls_all_removed(tmp_path: Path) -> None:
+    toml = (
+        '[git]\n'
+        'commit_parsers = [\n'
+        '  { message = "^feat", group = "Features" },\n'
+        '  { message = ".*", group = "Other1" },\n'
+        '  { message = ".*", group = "Other2" },\n'
+        ']\n'
+    )
+    cfg = _build_validation_config(_write_cliff_toml(tmp_path, toml))
+    parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
+    assert len(parsers) == 1
+    assert parsers[0]['message'] == '^feat'
+
+
 def test_raises_type_error_if_git_is_not_a_dict(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -139,21 +157,6 @@ def test_raises_type_error_if_commit_parsers_is_not_a_list(
         match='Expected commit_parsers to be an array',
     ):
         _build_validation_config(_write_cliff_toml(tmp_path))
-
-
-def test_multiple_catchalls_all_removed(tmp_path: Path) -> None:
-    toml = (
-        '[git]\n'
-        'commit_parsers = [\n'
-        '  { message = "^feat", group = "Features" },\n'
-        '  { message = ".*", group = "Other1" },\n'
-        '  { message = ".*", group = "Other2" },\n'
-        ']\n'
-    )
-    cfg = _build_validation_config(_write_cliff_toml(tmp_path, toml))
-    parsers: list[dict[str, object]] = cfg['git']['commit_parsers']  # type: ignore[index]
-    assert len(parsers) == 1
-    assert parsers[0]['message'] == '^feat'
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -349,19 +349,19 @@ wheels = [
 
 [[package]]
 name = "git-cliff"
-version = "2.11.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1f/e7/ac6a29b40b984a8e96667cf94c38e11d8e65127d0bc12f7d83c53341f6b8/git_cliff-2.11.0.tar.gz", hash = "sha256:d1acbd2deaf388b261bd2586f6865dfcb129d26e0c46c44ffb1d66e55a1b300e", size = 97837, upload-time = "2025-12-14T16:30:08.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/90/cf/dff8cd706d2e30e264cb3b9880235607188fb3ad596bfe6282147165bdcd/git_cliff-2.12.0.tar.gz", hash = "sha256:57b96b1f61167f85395353d6f47a89944b4882c03880312d53c09dacecb7ff86", size = 102106, upload-time = "2026-01-20T17:46:12.602Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/30/55/9e8a63f5b4936d3a5566aaf3e837fcc4d24a8ad151fb2734fda3e89d2e3d/git_cliff-2.11.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:28838025ec73c938716b88be74bf60e86069f4e059b992b032a7abcfe63709db", size = 6873322, upload-time = "2025-12-14T16:29:54.734Z" },
-    { url = "https://files.pythonhosted.org/packages/37/99/0c97716bda0536dddf31576b9ed68b51590b0e874ed515ecafef3ecb9590/git_cliff-2.11.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a7963311b52554edf2a9028a16b96e8d05eda4287898836bb4a219cfcedef06e", size = 6449906, upload-time = "2025-12-14T16:29:56.483Z" },
-    { url = "https://files.pythonhosted.org/packages/62/d6/1f1f37f7d9a3772c414f39fd6bc63dec20dacc62a19c0703f4772f0f8235/git_cliff-2.11.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bd59602ec1e411b2cfcafb74b4243c3a44bc0bd0e572f0b79a987a1ab5cfeccd", size = 6911494, upload-time = "2025-12-14T16:29:57.834Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/ee/101a3c92a16cd2585459e770d18bdcd8f2e2a61b4824fd26117a7b188eb7/git_cliff-2.11.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c74229eb78f784c9cde3b06013965ed710da565b539db9973379dc8426699d47", size = 7302130, upload-time = "2025-12-14T16:29:59.877Z" },
-    { url = "https://files.pythonhosted.org/packages/70/14/fe95f587de9090715302a4c1f73745f8f4859a87691d9e61005e69d7b8b4/git_cliff-2.11.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:374f7309d775fbbbda2d91ab765d7634f5357daa5b468a3b1782d116b157b524", size = 6920695, upload-time = "2025-12-14T16:30:01.244Z" },
-    { url = "https://files.pythonhosted.org/packages/8b/9e/8c749f3c9c3c8990557ed4a19b3a89d95c4b174e3c30eae91accfcd2ccc8/git_cliff-2.11.0-py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9863c39c705c2e0a7723154fbc39945442c867aabd6e3a255e45f5b6911a25fa", size = 7118353, upload-time = "2025-12-14T16:30:02.755Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/71/747927e43cf2de9ce2952e9861189a68ad09e13fb36be5db252e057b22b1/git_cliff-2.11.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:311b5663c53258fe609282a382b519cf1133a574af6d24d93c811c58eb1b1e07", size = 7543830, upload-time = "2025-12-14T16:30:04.266Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/c3/55cfdb3e19fd2548b4df58d9c5f9584d70b97f7cfe42921a484119d2f06a/git_cliff-2.11.0-py3-none-win32.whl", hash = "sha256:d2b242083d0614dc83ec99bb9adc70299d41520eaaca7f9d1f237cc8adc82735", size = 6349517, upload-time = "2025-12-14T16:30:05.498Z" },
-    { url = "https://files.pythonhosted.org/packages/72/1c/56cb4d6313c396df81e6b27c0c585aa35cded3b27424d4596f75e5737be9/git_cliff-2.11.0-py3-none-win_amd64.whl", hash = "sha256:0768fc1adb9e0f3698e4073de6bb9db8bbbd1e232191e98dcaaa8b8abc16462e", size = 7292950, upload-time = "2025-12-14T16:30:06.779Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a5/dc5f800f6a6dc175faa0787653119754dbbe81a9db1274e041443690287b/git_cliff-2.12.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e9ee9aa29e9435211712fdab4b5ec9fb432c4bc9d244e39351b2be57aeba7999", size = 6879200, upload-time = "2026-01-20T17:45:55.964Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/b6/0e251bd49700e767c47d8d524a690ad713a3aed4318074278438042b8f25/git_cliff-2.12.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e18512138db5ef57302155b1163c0a2cf43c3d79071a5e083883b65bb990218c", size = 6456349, upload-time = "2026-01-20T17:45:58.202Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/63/4e8780f60ad28e8c26ae2b2b365daff9ffa84cb441a5d5bf62c42a75e75a/git_cliff-2.12.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d24c3e334fdf309c59802ea1a9cd3828e92c8c7cacdd619bcabdc638e00e2ade", size = 6916209, upload-time = "2026-01-20T17:45:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/71/83/0bfab93065e10bcbe97e6136ccf6c1e8552715ef61c11eb678c397ff5fb0/git_cliff-2.12.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f1aa25b05a0315d0f58fc2ac21503538ca749fc3dd7476ee5d6bdf380d9f26ab", size = 7305605, upload-time = "2026-01-20T17:46:01.991Z" },
+    { url = "https://files.pythonhosted.org/packages/30/eb/78f624e387c1d9084ca7bcec3a8f28fda9fbbfbeb18c71465a727ee677b5/git_cliff-2.12.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:91eafd2f3ecf226b9a9c2a6c54d96df6042479927b48a97fcf46b728e8744bf1", size = 6927694, upload-time = "2026-01-20T17:46:03.798Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3f/735ddcb426c9f77498a039e9398162345c59f29c7990fbf22a530a15fb97/git_cliff-2.12.0-py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:26c9771a50a039252c67803f4c7f187f2ce9c5eea336b8cef890e94483af7a9d", size = 7118983, upload-time = "2026-01-20T17:46:05.535Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/97/68a5bd8063904fc43df7811e713483ccd831a877751283c6514dfb5b079e/git_cliff-2.12.0-py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:168f48b82f81ab8e1625d42adb739471623e25bd0a7e25b8c70490bad9e90e2b", size = 7541855, upload-time = "2026-01-20T17:46:07.348Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/00/2ed0bf7d71340c20906c1317db50cd6c14bdf0c90fa68a62885c9daf40a9/git_cliff-2.12.0-py3-none-win32.whl", hash = "sha256:4bc609a748c1c3493fe3e00a48305d343255ddff80e564fbf8eb954aac387784", size = 6354818, upload-time = "2026-01-20T17:46:09.117Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/fd/679d54e4ed37fdbadb58080219af8f35b5f659dd25e47ab1951b6349d1d0/git_cliff-2.12.0-py3-none-win_amd64.whl", hash = "sha256:c992b5756298251ecdd4db8abe087e90d00327f9eaf0c2470a44dbff64377d07", size = 7303564, upload-time = "2026-01-20T17:46:11.154Z" },
 ]
 
 [[package]]
@@ -718,6 +718,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pygithub" },
     { name = "semver" },
+    { name = "tomli-w" },
     { name = "typer" },
 ]
 
@@ -730,12 +731,13 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "git-cliff", specifier = ">=2.11.0,<3" },
+    { name = "git-cliff", specifier = ">=2.12.0,<3" },
     { name = "gitpython", specifier = ">=3.1.45,<4" },
     { name = "pydantic", specifier = ">=2.7.0,<3" },
     { name = "pydantic-settings", specifier = ">=2.7.0,<3" },
     { name = "pygithub", specifier = ">=2.8.1,<3" },
     { name = "semver", specifier = ">=3.0.1,<4" },
+    { name = "tomli-w", specifier = ">=1.0.0,<2" },
     { name = "typer", specifier = ">=0.24.1,<0.25" },
 ]
 
@@ -848,6 +850,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
     { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
     { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
+]
+
+[[package]]
+name = "tomli-w"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- `releez validate commit-message` validates a message against cliff.toml parsers, exits 0 (valid) or 1 (invalid)
- New `validate-pr-title` action mode + `pr-title` input replaces amannn/action-semantic-pull-request — one config to maintain
- Validation derives a temp cliff.toml with filter_unconventional=false, fail_on_unmatched_commit=true, and catch-all parsers stripped
- skip=true parsers (e.g. chore(release): 1.2.3) are accepted as valid
- tomli-w added as runtime dep for robust TOML round-trip
- 39 new tests: unit (config transforms + mocked subprocess), CLI (CliRunner), integration (20 parametrized cases against real git-cliff), action (act)
- .github/workflows/lint-pr-title.yaml rewritten to use the new mode