### PR TITLE
chore(release): 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.0.1] - 2026-05-27
+
+### 🐛 Bug Fixes
+
+- Fix doctor changelog check in monorepo mode (#57) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#57](https://github.com/hotdog-werx/releez/pull/57)
+
+- Add logging when git cliff fails (#56) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#56](https://github.com/hotdog-werx/releez/pull/56)
+
 ## [1.0.0] - 2026-05-19
 
 ### 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.0.0"
+version = "1.0.1"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -730,7 +730,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "1.0.0"
+version = "1.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## [1.0.1] - 2026-05-27


### 🐛 Bug Fixes

- Fix doctor changelog check in monorepo mode (#57) by [@jamestrousdale](https://github.com/jamestrousdale) in [#57](https://github.com/hotdog-werx/releez/pull/57)

- Add logging when git cliff fails (#56) by [@jamestrousdale](https://github.com/jamestrousdale) in [#56](https://github.com/hotdog-werx/releez/pull/56)

