### PR TITLE
chore(release): 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [1.0.2] - 2026-08-09
+
+### 🐛 Bug Fixes
+
+- Version override doesn't require prefix (#60) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#60](https://github.com/hotdog-werx/releez/pull/60)
+
+### ⚙️ Miscellaneous Tasks
+
+- Use devkit (#62) by [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#62](https://github.com/hotdog-werx/releez/pull/62)
+
 ## [1.0.1] - 2026-05-27
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.0.1"
+version = "1.0.2"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "1.0.1"
+version = "1.0.2"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## [1.0.2] - 2026-08-09


### 🐛 Bug Fixes

- Version override doesn't require prefix (#60) by [@jamestrousdale](https://github.com/jamestrousdale) in [#60](https://github.com/hotdog-werx/releez/pull/60)


### ⚙️ Miscellaneous Tasks

- Use devkit (#62) by [@jamestrousdale](https://github.com/jamestrousdale) in [#62](https://github.com/hotdog-werx/releez/pull/62)

