### PR TITLE
chore(release): 1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.4] - 2026-08-14
+
+### 🐛 Bug Fixes
+
+- Action is read-only to uv cache (#66) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#66](https://github.com/hotdog-werx/releez/pull/66)
+
 ## [1.0.3] - 2026-08-13
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.0.3"
+version = "1.0.4"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "1.0.3"
+version = "1.0.4"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## [1.0.4] - 2026-08-14


### 🐛 Bug Fixes

- Action is read-only to uv cache (#66) by [@jamestrousdale](https://github.com/jamestrousdale) in [#66](https://github.com/hotdog-werx/releez/pull/66)

