### PR TITLE
chore(release): 1.0.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.0.5] - 2026-08-17
+
+### 🐛 Bug Fixes
+
+- Fix action logic when in monorepo mode the app name and prefix vary (#68) by
+  [@jamestrousdale](https://github.com/jamestrousdale) in
+  [#68](https://github.com/hotdog-werx/releez/pull/68)
+
 ## [1.0.4] - 2026-08-14
 
 ### 🐛 Bug Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "releez"
 description = "CLI tool for helping to manage release processes."
 readme = "README.md"
 requires-python = ">=3.11"
-version = "1.0.4"
+version = "1.0.5"
 license = "MIT"
 authors = [{ name = "James Trousdale" }]
 keywords = [

--- a/uv.lock
+++ b/uv.lock
@@ -756,7 +756,7 @@ wheels = [
 
 [[package]]
 name = "releez"
-version = "1.0.4"
+version = "1.0.5"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## [1.0.5] - 2026-08-17


### 🐛 Bug Fixes

- Fix action logic when in monorepo mode the app name and prefix vary (#68) by [@jamestrousdale](https://github.com/jamestrousdale) in [#68](https://github.com/hotdog-werx/releez/pull/68)

